### PR TITLE
Add test coverage for timeline events

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,38 @@ hubspot.campaigns.events(opts, cb)
 hubspot.broadcasts.get(opts, cb)
 ```
 
+### Timeline
+
+```javascript
+hubspot.timelines.createEventType(applicationId, userId, data, cb)
+hubspot.timelines.updateEventType(applicationId, eventTypeId, data, cb)
+hubspot.timelines.createEventTypeProperty(
+  applicationId,
+  eventTypeId,
+  userId,
+  data,
+  cb,
+)
+hubspot.timelines.updateEventTypeProperty(
+  applicationId,
+  eventTypeId,
+  propertyId,
+  data,
+  cb,
+)
+hubspot.timelines.createTimelineEvent(applicationId, eventTypeId, data, cb)
+```
+
+NOTE: From the [documentation] for createTimelineEvent:
+
+> Returns a 204 response on success. Otherwise, you'll receive a 4xx error, with
+> more details about the specific error in the body of the response.
+
+So on success the body is empty or `undefined` and you will not get a result
+passed to a provided callback function
+
+[documentation]: https://developers.hubspot.com/docs/methods/timeline/create-or-update-event
+
 ### OAuth
 
 #### Obtain your authorization url

--- a/config.js
+++ b/config.js
@@ -1,0 +1,1 @@
+require('dotenv').config({ path: '.env' })

--- a/lib/client.js
+++ b/lib/client.js
@@ -59,7 +59,7 @@ class Client extends EventEmitter {
     this.oauth = new OAuth(this)
     this.owners = new Owner(this)
     this.pipelines = new Pipeline(this)
-    this.timeline = new Timeline(this)
+    this.timelines = new Timeline(this)
     this.subscriptions = new Subscription(this)
     this.workflows = new Workflow(this)
   }

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -1,43 +1,46 @@
+const guid = require('./utils/guid')
+
 class Timeline {
   constructor(client) {
     this.client = client
   }
 
   createEventType(applicationId, userId, data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: `/integrations/v1/${applicationId}/timeline/event-types?userId=${userId}`,
-        body: data,
-      },
-      cb,
-    )
-  }
-
-  updateEventType(eventId, applicationId, data, cb) {
-    const parameters = {
-      method: 'PUT',
-      path: `/integrations/v1/${applicationId}/timeline/event-types/${eventId}`,
-      body: data,
-    }
-
-    return this.client._request(parameters, cb)
-  }
-
-  createEventTypeProperty(eventId, applicationId, userId, data, cb) {
+    data['applicationId'] = data['applicationId'] || applicationId
     const parameters = {
       method: 'POST',
-      path: `/integrations/v1/${applicationId}/timeline/event-types/${eventId}/properties?userId=${userId}`,
+      path: `/integrations/v1/${applicationId}/timeline/event-types?userId=${userId}`,
+      body: data,
+    }
+    return this.client._request(parameters, cb)
+  }
+
+  updateEventType(applicationId, eventTypeId, data, cb) {
+    data['applicationId'] = data['applicationId'] || applicationId
+    const parameters = {
+      method: 'PUT',
+      path: `/integrations/v1/${applicationId}/timeline/event-types/${eventTypeId}`,
       body: data,
     }
 
     return this.client._request(parameters, cb)
   }
 
-  updateEventTypeProperty(eventId, applicationId, propertyId, data, cb) {
+  createEventTypeProperty(applicationId, eventTypeId, userId, data, cb) {
+    const parameters = {
+      method: 'POST',
+      path: `/integrations/v1/${applicationId}/timeline/event-types/${eventTypeId}/properties?userId=${userId}`,
+      body: data,
+    }
+
+    return this.client._request(parameters, cb)
+  }
+
+  updateEventTypeProperty(applicationId, eventTypeId, propertyId, data, cb) {
+    data['id'] = data['id'] || propertyId
     const parameters = {
       method: 'PUT',
-      path: `/integrations/v1/${applicationId}/timeline/event-types/${eventId}/properties/${propertyId}`,
+      path: `/integrations/v1/${applicationId}/timeline/event-types/${eventTypeId}/properties`,
       body: data,
     }
 
@@ -45,32 +48,11 @@ class Timeline {
   }
 
   createTimelineEvent(applicationId, eventTypeId, data, cb) {
-    if (
-      !this.client.clientId ||
-      !this.client.clientSecret ||
-      !this.client.redirectUri ||
-      !this.client.refreshToken
-    ) {
-      return cb(
-        new Error(
-          'You must init hubspot with a clientId/clientSecret/redirectUri/refreshToken and call hubspot.refreshAccessToken()',
-        ),
-      )
-    }
-
-    if (!data || (!data.email && !data.utk && !data.objectId)) {
-      return cb(
-        new Error(
-          'You must specify at least one of those in data : objectId, email, utk',
-        ),
-      )
-    }
-
     if (!data.id) {
       data.id = guid()
     }
 
-    data.eventTypeId = eventTypeId
+    data.eventTypeId = data.eventTypeId || eventTypeId
 
     const parameters = {
       method: 'PUT',
@@ -80,28 +62,6 @@ class Timeline {
 
     return this.client._request(parameters, cb)
   }
-}
-
-function guid() {
-  function s4() {
-    return Math.floor((1 + Math.random()) * 0x10000)
-      .toString(16)
-      .substring(1)
-  }
-  return (
-    s4() +
-    s4() +
-    '-' +
-    s4() +
-    '-' +
-    s4() +
-    '-' +
-    s4() +
-    '-' +
-    s4() +
-    s4() +
-    s4()
-  )
 }
 
 module.exports = Timeline

--- a/lib/utils/guid.js
+++ b/lib/utils/guid.js
@@ -1,0 +1,23 @@
+function guid() {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .substring(1)
+  }
+  return (
+    s4() +
+    s4() +
+    '-' +
+    s4() +
+    '-' +
+    s4() +
+    '-' +
+    s4() +
+    '-' +
+    s4() +
+    s4() +
+    s4()
+  )
+}
+
+module.exports = guid

--- a/package-lock.json
+++ b/package-lock.json
@@ -575,6 +575,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/request": "^2.47.0",
     "@types/request-promise": "^4.1.41",
     "chai": "^4.1.2",
+    "dotenv": "^6.2.0",
     "eslint": "^5.7.0",
     "eslint-config-prettier": "^3.3.0",
     "eslint-config-standard": "12.0.0",

--- a/test/helpers/nock_helper.js
+++ b/test/helpers/nock_helper.js
@@ -2,9 +2,9 @@ const nock = require('nock')
 
 class NockHelper {
   mockRateLimit() {
-    nock.disableNetConnect()
     nock('http://api.hubapi.com', { encodedQueryParams: true })
       .get('/integrations/v1/limit/daily')
+      .query({ hapikey: 'demo' })
       .reply(200, [
         {
           name: 'api-calls-daily',
@@ -19,6 +19,7 @@ class NockHelper {
 
   mockEndpoint(path, data) {
     return () => {
+      nock.disableNetConnect()
       this.mockRateLimit()
       nock('http://api.hubapi.com', { encodedQueryParams: true })
         .get(path)
@@ -27,21 +28,43 @@ class NockHelper {
     }
   }
 
-  mockPostEndpoint(path, data) {
+  mockOauthEndpoint(path, data) {
     return () => {
-      this.mockRateLimit()
-      nock('http://api.hubapi.com', { encodedQueryParams: true })
-        .post(path)
+      nock.disableNetConnect()
+      nock('http://api.hubapi.com')
+        .get(path)
         .reply(200, data)
     }
   }
 
-  mockOAuth() {
-    nock('http://api.hubapi.com')
-      .post('/oauth/v1/token')
-      .reply(200, {
-        access_token: 'qwerty782912',
-      })
+  mockPostOauthEndpoint(path, data, query = {}) {
+    return () => {
+      nock.disableNetConnect()
+      nock('http://api.hubapi.com', { encodedQueryParams: true })
+        .post(path, data)
+        .query(query)
+        .reply(200, data)
+    }
+  }
+
+  mockPutOauthEndpoint(path, data, query = {}) {
+    return () => {
+      nock.disableNetConnect()
+      nock('http://api.hubapi.com', { encodedQueryParams: true })
+        .put(path, data)
+        .query(query)
+        .reply(200, data)
+    }
+  }
+
+  mockFuzzyPutOauthEndpoint(path, regex, data, query = {}) {
+    return () => {
+      nock.disableNetConnect()
+      nock('http://api.hubapi.com', { encodedQueryParams: true })
+        .put(path, regex)
+        .query(query)
+        .reply(200, data)
+    }
   }
 
   resetNock() {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ./config.js

--- a/test/timeline.js
+++ b/test/timeline.js
@@ -1,90 +1,203 @@
-// const chai = require('chai')
-// const expect = chai.expect
+const { expect } = require('chai')
 const nockHelper = require('./helpers/nock_helper')
-
 const Hubspot = require('..')
 
+const userId = process.env.USER_ID || 23456
+const applicationId = process.env.APPLICATION_ID || 12345
+
 describe('timeline', function() {
-  let hubspot
-
-  before(() => {
-    nockHelper.mockRateLimit()
-    nockHelper.mockOAuth()
-
-    nockHelper.mockPostEndpoint(
-      /\/integrations\/v1\/[0-9]+\/timeline\/event-types'/,
+  const hubspot = new Hubspot({
+    accessToken: process.env.ACCESS_TOKEN || 'some-fake-token',
+  })
+  const headerTemplate =
+    '# Title for event {{id}}\nThis is an event for {{objectType}}'
+  const detailTemplate =
+    'This event happened on {{#formatDate timestamp}}{{/formatDate}}'
+  const createEventType = () =>
+    hubspot.timelines.createEventType(applicationId, userId, {
+      name: 'Test Event Type',
+      headerTemplate,
+      detailTemplate,
+    })
+  const createEventTypeProperty = eventTypeId =>
+    hubspot.timelines.createEventTypeProperty(
+      applicationId,
+      eventTypeId,
+      userId,
       {
-        id: 261,
-        name: 'Test Event Type',
-        headerTemplate:
-          '# Title for event {{id}}\nThis is an event for {{objectType}}',
-        detailTemplate:
-          'This event happened on {{#formatDate timestamp}}{{/formatDate}}',
-        applicationId: 123,
-        objectType: 'CONTACT',
+        name: 'NumericProperty',
+        label: 'Numeric Property',
+        propertyType: 'Numeric',
       },
     )
 
-    const params = {
-      clientId: '111',
-      clientSecret: 'abcdef',
-      redirectUri: 'https://example.com',
-      refreshToken: 'azerty123',
-    }
-    hubspot = new Hubspot(params)
-    hubspot.oauth.refreshAccessToken()
-  })
-  after(nockHelper.resetNock)
-
-  describe('EventType', () => {
-    it('should create an event type', async () => {
-      const result = await hubspot.timeline.createEventType(
-        123, // applicationId
-        123456, // userId
+  describe('createEventType', () => {
+    beforeEach(
+      nockHelper.mockPostOauthEndpoint(
+        `/integrations/v1/${applicationId}/timeline/event-types`,
         {
-          name: 'New Event Type', // name
-          headerTemplate:
-            '# Title for event {{id}}\nThis is an event for {{objectType}}', // headerTemplate
-          detailTemplate:
-            'This event happened on {{#formatDate timestamp}}{{/formatDate}}', // detailTemplate
+          name: 'Test Event Type',
+          headerTemplate,
+          detailTemplate,
+          applicationId,
         },
-      )
-      console.log('result')
-      console.log(result)
+        { userId },
+      ),
+    )
+    afterEach(nockHelper.resetNock)
+
+    it('should create an event type', async () => {
+      return hubspot.timelines
+        .createEventType(applicationId, userId, {
+          name: 'Test Event Type',
+          headerTemplate,
+          detailTemplate,
+        })
+        .then(data => {
+          expect(data.headerTemplate).to.eq(headerTemplate)
+          expect(data.detailTemplate).to.eq(detailTemplate)
+        })
     })
   })
 
-  // describe('EventTypeProperty', () => {
-  //   it('should create an event type property', () => {
-  //     return hubspot.timeline
-  //       .createEventTypeProperty(
-  //         '123-567-890', // eventId
-  //         123, // applicationId
-  //         100, // userId
-  //         {
-  //           name: 'EventTypePropertyName', // name
-  //           label: 'label', // label
-  //           propertyType: 'String', // propertyType
-  //         },
-  //       )
-  //       .then(res => {})
-  //   })
-  // })
+  describe('updateEventType', () => {
+    let eventTypeId
+    beforeEach(() => {
+      if (process.env.NOCK_OFF) {
+        return createEventType().then(data => (eventTypeId = data.id))
+      } else {
+        eventTypeId = 123
+        return nockHelper.mockPutOauthEndpoint(
+          `/integrations/v1/${applicationId}/timeline/event-types/123`,
+          {
+            name: 'Edited Event Type',
+            headerTemplate,
+            detailTemplate,
+            applicationId,
+          },
+        )()
+      }
+    })
+    afterEach(nockHelper.resetNock)
 
-  // describe('TimelineEvent', () => {
-  //   it('should create an event timeline event', () => {
-  //     return hubspot.timeline
-  //       .createEventTypeProperty(
-  //         123, // applicationId
-  //         222, // eventTypeId,
-  //         {
-  //           objectId: 321,
-  //           data: {
-  //             presentationId: '123',
-  //           },
-  //         },
-  //       )
-  //       .then(res => {})
-  //   })
-  // })
+    it('should update an event type', async () => {
+      return hubspot.timelines
+        .updateEventType(applicationId, eventTypeId, {
+          name: 'Edited Event Type',
+          headerTemplate,
+          detailTemplate,
+        })
+        .then(data => {
+          expect(data.name).to.eq('Edited Event Type')
+        })
+    })
+  })
+
+  describe('createEventTypeProperty', () => {
+    let eventTypeId
+    beforeEach(() => {
+      if (process.env.NOCK_OFF) {
+        return createEventType().then(data => (eventTypeId = data.id))
+      } else {
+        eventTypeId = 123
+        return nockHelper.mockPostOauthEndpoint(
+          `/integrations/v1/${applicationId}/timeline/event-types/123/properties`,
+          {
+            name: 'NumericProperty',
+            label: 'Numeric Property',
+            propertyType: 'Numeric',
+          },
+          { userId },
+        )()
+      }
+    })
+    afterEach(nockHelper.resetNock)
+
+    it('should create an event type property', async () => {
+      return hubspot.timelines
+        .createEventTypeProperty(applicationId, eventTypeId, userId, {
+          name: 'NumericProperty',
+          label: 'Numeric Property',
+          propertyType: 'Numeric',
+        })
+        .then(data => {
+          expect(data.name).to.eq('NumericProperty')
+        })
+    })
+  })
+
+  describe('updateEventTypeProperty', () => {
+    let eventTypeId
+    let eventTypePropertyId
+    beforeEach(() => {
+      if (process.env.NOCK_OFF) {
+        return createEventType().then(data => {
+          eventTypeId = data.id
+          return createEventTypeProperty(eventTypeId).then(
+            data => (eventTypePropertyId = data.id),
+          )
+        })
+      } else {
+        eventTypeId = 123
+        eventTypePropertyId = 234
+        return nockHelper.mockPutOauthEndpoint(
+          `/integrations/v1/${applicationId}/timeline/event-types/123/properties`,
+          {
+            name: 'NumericProperty',
+            label: 'A new label',
+            propertyType: 'Numeric',
+            id: eventTypePropertyId,
+          },
+        )()
+      }
+    })
+    afterEach(nockHelper.resetNock)
+
+    it('should update an event type property', async () => {
+      return hubspot.timelines
+        .updateEventTypeProperty(
+          applicationId,
+          eventTypeId,
+          eventTypePropertyId,
+          {
+            name: 'NumericProperty',
+            label: 'A new label',
+            propertyType: 'Numeric',
+          },
+        )
+        .then(data => {
+          expect(data.label).to.eq('A new label')
+        })
+    })
+  })
+
+  describe('createTimelineEvent', () => {
+    let eventTypeId
+    beforeEach(() => {
+      if (process.env.NOCK_OFF) {
+        return createEventType().then(data => (eventTypeId = data.id))
+      } else {
+        eventTypeId = 123
+        return nockHelper.mockFuzzyPutOauthEndpoint(
+          `/integrations/v1/${applicationId}/timeline/event`,
+          body =>
+            !!body.id &&
+            body.email === 'test@test.com' &&
+            body.eventTypeId === eventTypeId,
+          undefined,
+        )()
+      }
+    })
+    afterEach(nockHelper.resetNock)
+
+    it('should create an event', async () => {
+      return hubspot.timelines
+        .createTimelineEvent(applicationId, eventTypeId, {
+          email: 'test@test.com',
+        })
+        .then(data => {
+          expect(data).to.be.an('undefined')
+        })
+    })
+  })
 })


### PR DESCRIPTION
Why:

We would like to have some tests around timeline events to avoid
breaking changes.

This PR:

* Introduce dotenv for running tests
* Adds test cases for timeline
* Adds `id` in updateEventTypeProperty and corrects the url
* Removes checks already covered by hubspot



-------




This introduces DotEnv to more easily run the tests with environment variables. This also gets the first timeline test passing using nock.

To turn off nock and hit the real api in the test, first create a `.env` file locally that looks like:

```
APPLICATION_ID=123456 # The ID of the OAuth app you're creating the event type for.
USER_ID=1234567 # Your HubSpot user ID. This can be found in the same place as your Developer HAPIkey in your Developer portal.
ACCESS_TOKEN="some-long-token" # This can be generated following the instructions found here https://github.com/HubSpot/oauth-quickstart-nodejs
```